### PR TITLE
Resolve most of the issues with config.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,6 +789,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -1584,6 +1585,7 @@ dependencies = [
  "ide",
  "ide-db",
  "ide-ssr",
+ "indexmap 2.0.0",
  "itertools",
  "la-arena 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "load-cargo",

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -47,12 +47,12 @@ triomphe.workspace = true
 toml = "0.8.8"
 nohash-hasher.workspace = true
 always-assert = "0.1.2"
+indexmap = { version = "2.0.0", features = ["serde"] }
 
-# These 3 deps are not used by r-a directly, but we list them here to lock in their versions
+# These 2 deps are not used by r-a directly, but we list them here to lock in their versions
 # in our transitive deps to prevent them from pulling in windows-sys 0.45.0
 mio = "=0.8.5"
 parking_lot_core = "=0.9.6"
-indexmap = { version = "2.0.0", features = ["serde"] }
 
 cfg.workspace = true
 flycheck.workspace = true

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -52,6 +52,7 @@ always-assert = "0.1.2"
 # in our transitive deps to prevent them from pulling in windows-sys 0.45.0
 mio = "=0.8.5"
 parking_lot_core = "=0.9.6"
+indexmap = { version = "2.0.0", features = ["serde"] }
 
 cfg.workspace = true
 flycheck.workspace = true

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -107,21 +107,21 @@ config_data! {
         /// cargo check --quiet --workspace --message-format=json --all-targets
         /// ```
         /// .
-        cargo_buildScripts_overrideCommand: Option<Vec<String>> = Option::<Vec<String>>::None,
+        cargo_buildScripts_overrideCommand: Option<Vec<String>> = None,
         /// Use `RUSTC_WRAPPER=rust-analyzer` when running build scripts to
         /// avoid checking unnecessary things.
         cargo_buildScripts_useRustcWrapper: bool = true,
         /// List of cfg options to enable with the given values.
-        cargo_cfgs: FxHashMap<String, String> = FxHashMap::<String,String>::default(),
+        cargo_cfgs: FxHashMap<String, String> = FxHashMap::default(),
         /// Extra arguments that are passed to every cargo invocation.
-        cargo_extraArgs: Vec<String> = Vec::<String>::new(),
+        cargo_extraArgs: Vec<String> = vec![],
         /// Extra environment variables that will be set when running cargo, rustc
         /// or other commands within the workspace. Useful for setting RUSTFLAGS.
-        cargo_extraEnv: FxHashMap<String, String> = FxHashMap::<String,String>::default(),
+        cargo_extraEnv: FxHashMap<String, String> = FxHashMap::default(),
         /// List of features to activate.
         ///
         /// Set this to `"all"` to pass `--all-features` to cargo.
-        cargo_features: CargoFeaturesDef      = CargoFeaturesDef::Selected(Vec::<String>::new()),
+        cargo_features: CargoFeaturesDef      = CargoFeaturesDef::Selected(vec![]),
         /// Whether to pass `--no-default-features` to cargo.
         cargo_noDefaultFeatures: bool    = false,
         /// Relative path to the sysroot, or "discover" to try to automatically find it via
@@ -135,11 +135,11 @@ config_data! {
         /// `{cargo.sysroot}/lib/rustlib/src/rust/library`.
         ///
         /// This option does not take effect until rust-analyzer is restarted.
-        cargo_sysrootSrc: Option<String>    = Option::<String>::None,
+        cargo_sysrootSrc: Option<String>    = None,
         /// Compilation target override (target triple).
         // FIXME(@poliorcetics): move to multiple targets here too, but this will need more work
         // than `checkOnSave_target`
-        cargo_target: Option<String>     = Option::<String>::None,
+        cargo_target: Option<String>     = None,
         /// Unsets the implicit `#[cfg(test)]` for the specified crates.
         cargo_unsetTest: Vec<String>     = vec!["core".to_string()],
 
@@ -151,19 +151,19 @@ config_data! {
         /// Cargo command to use for `cargo check`.
         check_command | checkOnSave_command: String                      = "check".to_string(),
         /// Extra arguments for `cargo check`.
-        check_extraArgs | checkOnSave_extraArgs: Vec<String>             = Vec::<String>::new(),
+        check_extraArgs | checkOnSave_extraArgs: Vec<String>             = vec![],
         /// Extra environment variables that will be set when running `cargo check`.
         /// Extends `#rust-analyzer.cargo.extraEnv#`.
-        check_extraEnv | checkOnSave_extraEnv: FxHashMap<String, String> = FxHashMap::<String,String>::default(),
+        check_extraEnv | checkOnSave_extraEnv: FxHashMap<String, String> = FxHashMap::default(),
         /// List of features to activate. Defaults to
         /// `#rust-analyzer.cargo.features#`.
         ///
         /// Set to `"all"` to pass `--all-features` to Cargo.
-        check_features | checkOnSave_features: Option<CargoFeaturesDef>  = Option::<CargoFeaturesDef>::None,
+        check_features | checkOnSave_features: Option<CargoFeaturesDef>  = None,
         /// List of `cargo check` (or other command specified in `check.command`) diagnostics to ignore.
         ///
         /// For example for `cargo check`: `dead_code`, `unused_imports`, `unused_variables`,...
-        check_ignore: FxHashSet<String> = FxHashSet::<String>::default(),
+        check_ignore: FxHashSet<String> = FxHashSet::default(),
         /// Specifies the working directory for running checks.
         /// - "workspace": run checks for workspaces in the corresponding workspaces' root directories.
         // FIXME: Ideally we would support this in some way
@@ -180,7 +180,7 @@ config_data! {
         check_invocationStrategy | checkOnSave_invocationStrategy: InvocationStrategy = InvocationStrategy::PerWorkspace,
         /// Whether to pass `--no-default-features` to Cargo. Defaults to
         /// `#rust-analyzer.cargo.noDefaultFeatures#`.
-        check_noDefaultFeatures | checkOnSave_noDefaultFeatures: Option<bool>         = Option::<bool>::None,
+        check_noDefaultFeatures | checkOnSave_noDefaultFeatures: Option<bool>         = None,
         /// Override the command rust-analyzer uses instead of `cargo check` for
         /// diagnostics on save. The command is required to output json and
         /// should therefore include `--message-format=json` or a similar option
@@ -203,18 +203,18 @@ config_data! {
         /// cargo check --workspace --message-format=json --all-targets
         /// ```
         /// .
-        check_overrideCommand | checkOnSave_overrideCommand: Option<Vec<String>>             = Option::<Vec<String>>::None,
+        check_overrideCommand | checkOnSave_overrideCommand: Option<Vec<String>>             = None,
         /// Check for specific targets. Defaults to `#rust-analyzer.cargo.target#` if empty.
         ///
         /// Can be a single target, e.g. `"x86_64-unknown-linux-gnu"` or a list of targets, e.g.
         /// `["aarch64-apple-darwin", "x86_64-apple-darwin"]`.
         ///
         /// Aliased as `"checkOnSave.targets"`.
-        check_targets | checkOnSave_targets | checkOnSave_target: Option<CheckOnSaveTargets> = Option::<CheckOnSaveTargets>::None,
+        check_targets | checkOnSave_targets | checkOnSave_target: Option<CheckOnSaveTargets> = None,
 
 
         /// List of rust-analyzer diagnostics to disable.
-        diagnostics_disabled: FxHashSet<String> = FxHashSet::<String>::default(),
+        diagnostics_disabled: FxHashSet<String> = FxHashSet::default(),
         /// Whether to show native rust-analyzer diagnostics.
         diagnostics_enable: bool                = true,
         /// Whether to show experimental rust-analyzer diagnostics that might
@@ -222,21 +222,21 @@ config_data! {
         diagnostics_experimental_enable: bool    = false,
         /// Map of prefixes to be substituted when parsing diagnostic file paths.
         /// This should be the reverse mapping of what is passed to `rustc` as `--remap-path-prefix`.
-        diagnostics_remapPrefix: FxHashMap<String, String> = FxHashMap::<String,String>::default(),
+        diagnostics_remapPrefix: FxHashMap<String, String> = FxHashMap::default(),
         /// List of warnings that should be displayed with hint severity.
         ///
         /// The warnings will be indicated by faded text or three dots in code
         /// and will not show up in the `Problems Panel`.
-        diagnostics_warningsAsHint: Vec<String> = Vec::<String>::new(),
+        diagnostics_warningsAsHint: Vec<String> = vec![],
         /// List of warnings that should be displayed with info severity.
         ///
         /// The warnings will be indicated by a blue squiggly underline in code
         /// and a blue icon in the `Problems Panel`.
-        diagnostics_warningsAsInfo: Vec<String> = Vec::<String>::new(),
+        diagnostics_warningsAsInfo: Vec<String> = vec![],
         /// These directories will be ignored by rust-analyzer. They are
         /// relative to the workspace root, and globs are not supported. You may
         /// also need to add the folders to Code's `files.watcherExclude`.
-        files_excludeDirs: Vec<PathBuf> = Vec::<PathBuf>::new(),
+        files_excludeDirs: Vec<PathBuf> = vec![],
         /// Controls file watching implementation.
         files_watcher: FilesWatcherDef = FilesWatcherDef::Client,
 
@@ -280,18 +280,18 @@ config_data! {
         ///
         /// Elements must be paths pointing to `Cargo.toml`,
         /// `rust-project.json`, or JSON objects in `rust-project.json` format.
-        linkedProjects: Vec<ManifestOrProjectJson> = Vec::<ManifestOrProjectJson>::new(),
+        linkedProjects: Vec<ManifestOrProjectJson> = vec![],
 
         /// Number of syntax trees rust-analyzer keeps in memory. Defaults to 128.
-        lru_capacity: Option<usize>                 = Option::<usize>::None,
+        lru_capacity: Option<usize>                 = None,
         /// Sets the LRU capacity of the specified queries.
-        lru_query_capacities: FxHashMap<Box<str>, usize> = FxHashMap::<Box<str>, usize>::default(),
+        lru_query_capacities: FxHashMap<Box<str>, usize> = FxHashMap::default(),
 
         /// Whether to show `can't find Cargo.toml` error message.
         notifications_cargoTomlNotFound: bool      = true,
 
         /// How many worker threads in the main loop. The default `null` means to pick automatically.
-        numThreads: Option<usize> = Option::<usize>::None,
+        numThreads: Option<usize> = None,
 
         /// Expand attribute macros. Requires `#rust-analyzer.procMacro.enable#` to be set.
         procMacro_attributes_enable: bool = true,
@@ -300,18 +300,18 @@ config_data! {
         /// These proc-macros will be ignored when trying to expand them.
         ///
         /// This config takes a map of crate names with the exported proc-macro names to ignore as values.
-        procMacro_ignored: FxHashMap<Box<str>, Box<[Box<str>]>>          = FxHashMap::<Box<str>, Box<[Box<str>]>>::default(),
+        procMacro_ignored: FxHashMap<Box<str>, Box<[Box<str>]>>          = FxHashMap::default(),
         /// Internal config, path to proc-macro server executable.
-        procMacro_server: Option<PathBuf>          = Option::<PathBuf>::None,
+        procMacro_server: Option<PathBuf>          = None,
 
         /// Exclude imports from find-all-references.
         references_excludeImports: bool = false,
 
         /// Command to be executed instead of 'cargo' for runnables.
-        runnables_command: Option<String> = Option::<String>::None,
+        runnables_command: Option<String> = None,
         /// Additional arguments to be passed to cargo for runnables such as
         /// tests or binaries. For example, it may be `--release`.
-        runnables_extraArgs: Vec<String>   = Vec::<String>::new(),
+        runnables_extraArgs: Vec<String>   = vec![],
 
         /// Optional path to a rust-analyzer specific target directory.
         /// This prevents rust-analyzer's `cargo check` from locking the `Cargo.lock`
@@ -319,7 +319,7 @@ config_data! {
         ///
         /// Set to `true` to use a subdirectory of the existing target directory or
         /// set to a path relative to the workspace to use that path.
-        rust_analyzerTargetDir: Option<TargetDirectory> = Option::<TargetDirectory>::None,
+        rust_analyzerTargetDir: Option<TargetDirectory> = None,
 
         /// Path to the Cargo.toml of the rust compiler workspace, for usage in rustc_private
         /// projects, or "discover" to try to automatically find it if the `rustc-dev` component
@@ -329,16 +329,16 @@ config_data! {
         /// crates must set `[package.metadata.rust-analyzer] rustc_private=true` to use it.
         ///
         /// This option does not take effect until rust-analyzer is restarted.
-        rustc_source: Option<String> = Option::<String>::None,
+        rustc_source: Option<String> = None,
 
         /// Additional arguments to `rustfmt`.
-        rustfmt_extraArgs: Vec<String>               = Vec::<String>::new(),
+        rustfmt_extraArgs: Vec<String>               = vec![],
         /// Advanced option, fully override the command rust-analyzer uses for
         /// formatting. This should be the equivalent of `rustfmt` here, and
         /// not that of `cargo fmt`. The file contents will be passed on the
         /// standard input and the formatted result will be read from the
         /// standard output.
-        rustfmt_overrideCommand: Option<Vec<String>> = Option::<Vec<String>>::None,
+        rustfmt_overrideCommand: Option<Vec<String>> = None,
         /// Enables the use of rustfmt's unstable range formatting command for the
         /// `textDocument/rangeFormatting` request. The rustfmt option is unstable and only
         /// available on a nightly build.
@@ -374,14 +374,14 @@ config_data! {
         /// Whether to show full function/method signatures in completion docs.
         completion_fullFunctionSignatures_enable: bool = false,
         /// Maximum number of completions to return. If `None`, the limit is infinite.
-        completion_limit: Option<usize> = Option::<usize>::None,
+        completion_limit: Option<usize> = None,
         /// Whether to show postfix snippets like `dbg`, `if`, `not`, etc.
         completion_postfix_enable: bool         = true,
         /// Enables completions of private items and fields that are defined in the current workspace even if they are not visible at the current position.
         completion_privateEditable_enable: bool = false,
         /// Custom completion snippets.
         // NOTE: Keep this list in sync with the feature docs of user snippets.
-        completion_snippets_custom: FxHashMap<String, SnippetDef> = FxHashMap::<String, SnippetDef>::default() ,
+        completion_snippets_custom: FxHashMap<String, SnippetDef> = FxHashMap::default(),
 
         /// Enables highlighting of related references while the cursor is on `break`, `loop`, `while`, or `for` keywords.
         highlightRelated_breakPoints_enable: bool = true,
@@ -420,15 +420,15 @@ config_data! {
         /// Use markdown syntax for links on hover.
         hover_links_enable: bool = true,
         /// How to render the align information in a memory layout hover.
-        hover_memoryLayout_alignment: Option<MemoryLayoutHoverRenderKindDef> = Option::<MemoryLayoutHoverRenderKindDef>::Some(MemoryLayoutHoverRenderKindDef::Hexadecimal),
+        hover_memoryLayout_alignment: Option<MemoryLayoutHoverRenderKindDef> = Some(MemoryLayoutHoverRenderKindDef::Hexadecimal),
         /// Whether to show memory layout data on hover.
         hover_memoryLayout_enable: bool = true,
         /// How to render the niche information in a memory layout hover.
-        hover_memoryLayout_niches: Option<bool> = Option::<bool>::Some(false),
+        hover_memoryLayout_niches: Option<bool> = Some(false),
         /// How to render the offset information in a memory layout hover.
-        hover_memoryLayout_offset: Option<MemoryLayoutHoverRenderKindDef> = Option::<MemoryLayoutHoverRenderKindDef>::Some(MemoryLayoutHoverRenderKindDef::Hexadecimal),
+        hover_memoryLayout_offset: Option<MemoryLayoutHoverRenderKindDef> = Some(MemoryLayoutHoverRenderKindDef::Hexadecimal),
         /// How to render the size information in a memory layout hover.
-        hover_memoryLayout_size: Option<MemoryLayoutHoverRenderKindDef> =Option::<MemoryLayoutHoverRenderKindDef>::Some(MemoryLayoutHoverRenderKindDef::Both),
+        hover_memoryLayout_size: Option<MemoryLayoutHoverRenderKindDef> = Some(MemoryLayoutHoverRenderKindDef::Both),
 
         /// Whether to enforce the import granularity setting for all files. If set to false rust-analyzer will try to keep import styles consistent per file.
         imports_granularity_enforce: bool              = false,
@@ -472,7 +472,7 @@ config_data! {
         /// Whether to prefer using parameter names as the name for elided lifetime hints if possible.
         inlayHints_lifetimeElisionHints_useParameterNames: bool    = false,
         /// Maximum length for inlay hints. Set to null to have an unlimited length.
-        inlayHints_maxLength: Option<usize>                        = Option::<usize>::Some(25),
+        inlayHints_maxLength: Option<usize>                        = Some(25_usize),
         /// Whether to show function parameter name inlay hints at the call
         /// site.
         inlayHints_parameterHints_enable: bool                     = true,
@@ -2230,7 +2230,7 @@ macro_rules! _config_data {
                         error_sink,
                         stringify!($field),
                         None$(.or(Some(stringify!($alias))))*,
-                        $default,
+                        $default as $ty,
                     ),
                 )*}
             }
@@ -2248,7 +2248,7 @@ macro_rules! _config_data {
                         error_sink,
                         stringify!($field2),
                         None$(.or(Some(stringify!($alias2))))*,
-                        $default2,
+                        $default2 as $ty2,
                     ),
                 )*}
             }
@@ -2265,7 +2265,7 @@ macro_rules! _config_data {
                         error_sink,
                         stringify!($field3),
                         None$(.or(Some(stringify!($alias3))))*,
-                        $default3,
+                        $default3 as $ty3,
                     ),
                 )*}
             }
@@ -2288,7 +2288,7 @@ macro_rules! _config_data {
                         error_sink,
                         stringify!($field),
                         None$(.or(Some(stringify!($alias))))*,
-                        $default,
+                        $default as $ty,
                     ),
                 )*
                 $(
@@ -2297,7 +2297,7 @@ macro_rules! _config_data {
                         error_sink,
                         stringify!($field2),
                         None$(.or(Some(stringify!($alias2))))*,
-                        $default2,
+                        $default2 as $ty2,
                     ),
                 )*
                 $(
@@ -2306,7 +2306,7 @@ macro_rules! _config_data {
                         error_sink,
                         stringify!($field3),
                         None$(.or(Some(stringify!($alias3))))*,
-                        $default3,
+                        $default3 as $ty3,
                     ),
                 )*}
             }
@@ -2318,7 +2318,7 @@ macro_rules! _config_data {
                         error_sink,
                         stringify!($field),
                         None$(.or(Some(stringify!($alias))))*,
-                        $default,
+                        $default as $ty,
                     ),
                 )*
                 $(
@@ -2327,7 +2327,7 @@ macro_rules! _config_data {
                         error_sink,
                         stringify!($field2),
                         None$(.or(Some(stringify!($alias2))))*,
-                        $default2,
+                        $default2 as $ty2,
                     ),
                 )*
                 $(
@@ -2336,7 +2336,7 @@ macro_rules! _config_data {
                         error_sink,
                         stringify!($field3),
                         None$(.or(Some(stringify!($alias3))))*,
-                        $default3,
+                        $default3 as $ty3,
                     ),
                 )*}
             }
@@ -2347,19 +2347,19 @@ macro_rules! _config_data {
                         let field = stringify!($field);
                         let ty = stringify!($ty);
 
-                        (field, ty, &[$($doc),*], serde_json::to_string(&$default).unwrap().as_str())
+                        (field, ty, &[$($doc),*], serde_json::to_string(&($default as $ty)).unwrap().as_str())
                     },)*
                     $({
                         let field = stringify!($field2);
                         let ty = stringify!($ty2);
 
-                        (field, ty, &[$($doc2),*], serde_json::to_string(&$default2).unwrap().as_str())
+                        (field, ty, &[$($doc2),*], serde_json::to_string(&($default2 as $ty2)).unwrap().as_str())
                     },)*
                     $({
                         let field = stringify!($field3);
                         let ty = stringify!($ty3);
 
-                        (field, ty, &[$($doc3),*], serde_json::to_string(&$default3).unwrap().as_str())
+                        (field, ty, &[$($doc3),*], serde_json::to_string(&($default3 as $ty3)).unwrap().as_str())
                     },)*
                 ])
             }
@@ -2371,7 +2371,7 @@ macro_rules! _config_data {
                         let field = stringify!($field3);
                         let ty = stringify!($ty3);
 
-                        (field, ty, &[$($doc3),*], $default3)
+                        (field, ty, &[$($doc3),*], $default3 as $ty3)
                     },)*
                 ])
             }

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -472,7 +472,7 @@ config_data! {
         /// Whether to prefer using parameter names as the name for elided lifetime hints if possible.
         inlayHints_lifetimeElisionHints_useParameterNames: bool    = false,
         /// Maximum length for inlay hints. Set to null to have an unlimited length.
-        inlayHints_maxLength: Option<usize>                        = Some(25_usize),
+        inlayHints_maxLength: Option<usize>                        = Some(25),
         /// Whether to show function parameter name inlay hints at the call
         /// site.
         inlayHints_parameterHints_enable: bool                     = true,
@@ -2230,7 +2230,7 @@ macro_rules! _config_data {
                         error_sink,
                         stringify!($field),
                         None$(.or(Some(stringify!($alias))))*,
-                        $default as $ty,
+                        { let default_: $ty = $default; default_ },
                     ),
                 )*}
             }
@@ -2248,7 +2248,7 @@ macro_rules! _config_data {
                         error_sink,
                         stringify!($field2),
                         None$(.or(Some(stringify!($alias2))))*,
-                        $default2 as $ty2,
+                        { let default_: $ty2 = $default2; default_ },
                     ),
                 )*}
             }
@@ -2265,7 +2265,7 @@ macro_rules! _config_data {
                         error_sink,
                         stringify!($field3),
                         None$(.or(Some(stringify!($alias3))))*,
-                        $default3 as $ty3,
+                        { let default_: $ty3 = $default3; default_ },
                     ),
                 )*}
             }
@@ -2288,7 +2288,7 @@ macro_rules! _config_data {
                         error_sink,
                         stringify!($field),
                         None$(.or(Some(stringify!($alias))))*,
-                        $default as $ty,
+                        { let default_: $ty = $default; default_ },
                     ),
                 )*
                 $(
@@ -2297,7 +2297,7 @@ macro_rules! _config_data {
                         error_sink,
                         stringify!($field2),
                         None$(.or(Some(stringify!($alias2))))*,
-                        $default2 as $ty2,
+                        { let default_: $ty2 = $default2; default_ },
                     ),
                 )*
                 $(
@@ -2306,7 +2306,7 @@ macro_rules! _config_data {
                         error_sink,
                         stringify!($field3),
                         None$(.or(Some(stringify!($alias3))))*,
-                        $default3 as $ty3,
+                        { let default_: $ty3 = $default3; default_ },
                     ),
                 )*}
             }
@@ -2318,7 +2318,7 @@ macro_rules! _config_data {
                         error_sink,
                         stringify!($field),
                         None$(.or(Some(stringify!($alias))))*,
-                        $default as $ty,
+                        { let default_: $ty = $default; default_ },
                     ),
                 )*
                 $(
@@ -2327,7 +2327,7 @@ macro_rules! _config_data {
                         error_sink,
                         stringify!($field2),
                         None$(.or(Some(stringify!($alias2))))*,
-                        $default2 as $ty2,
+                        { let default_: $ty2 = $default2; default_ },
                     ),
                 )*
                 $(
@@ -2336,7 +2336,7 @@ macro_rules! _config_data {
                         error_sink,
                         stringify!($field3),
                         None$(.or(Some(stringify!($alias3))))*,
-                        $default3 as $ty3,
+                        { let default_: $ty3 = $default3; default_ },
                     ),
                 )*}
             }
@@ -2347,19 +2347,19 @@ macro_rules! _config_data {
                         let field = stringify!($field);
                         let ty = stringify!($ty);
 
-                        (field, ty, &[$($doc),*], serde_json::to_string(&($default as $ty)).unwrap().as_str())
+                        (field, ty, &[$($doc),*], serde_json::to_string(&{ let default_: $ty = $default; default_ }).unwrap().as_str())
                     },)*
                     $({
                         let field = stringify!($field2);
                         let ty = stringify!($ty2);
 
-                        (field, ty, &[$($doc2),*], serde_json::to_string(&($default2 as $ty2)).unwrap().as_str())
+                        (field, ty, &[$($doc2),*], serde_json::to_string(&{ let default_: $ty2 = $default2; default_ }).unwrap().as_str())
                     },)*
                     $({
                         let field = stringify!($field3);
                         let ty = stringify!($ty3);
 
-                        (field, ty, &[$($doc3),*], serde_json::to_string(&($default3 as $ty3)).unwrap().as_str())
+                        (field, ty, &[$($doc3),*], serde_json::to_string(&{ let default_: $ty3 = $default3; default_ }).unwrap().as_str())
                     },)*
                 ])
             }

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -2248,13 +2248,10 @@ macro_rules! _config_data {
                     $({
                         let field = stringify!($field);
                         let ty = stringify!($ty);
+                        let default =
+                            serde_json::to_string(&{ let default_: $ty = $default; default_ }).unwrap();
 
-                        (
-                            field,
-                            ty,
-                            &[$($doc),*],
-                            serde_json::to_string(&{ let default_: $ty = $default; default_ }).unwrap(),
-                        )
+                        (field, ty, &[$($doc),*], default)
                     },)*
                 ])
             }
@@ -2309,6 +2306,8 @@ impl ConfigData {
         GlobalConfigData::schema_fields(&mut fields);
         LocalConfigData::schema_fields(&mut fields);
         ClientConfigData::schema_fields(&mut fields);
+        // HACK: sort the fields, so the diffs on the generated docs/schema are smaller
+        fields.sort_by_key(|&(x, ..)| x);
         fields
     }
 

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -142,7 +142,7 @@ config_data! {
         // than `checkOnSave_target`
         cargo_target: Option<String>     = None,
         /// Unsets the implicit `#[cfg(test)]` for the specified crates.
-        cargo_unsetTest: Vec<String>     = @from_str: r#"["core"]"#,
+        cargo_unsetTest: Vec<String>     = @verbatim: r#"["core"]"#,
 
         /// Run the check command for diagnostics on save.
         checkOnSave | checkOnSave_enable: bool                         = true,
@@ -2303,7 +2303,7 @@ pub enum TargetDirectory {
 }
 
 macro_rules! _default_val {
-    (@from_str: $s:literal, $ty:ty) => {{
+    (@verbatim: $s:literal, $ty:ty) => {{
         let default_: $ty = serde_json::from_str(&$s).unwrap();
         default_
     }};
@@ -2314,7 +2314,7 @@ macro_rules! _default_val {
 }
 
 macro_rules! _default_str {
-    (@from_str: $s:literal, $_ty:ty) => {
+    (@verbatim: $s:literal, $_ty:ty) => {
         $s.to_string()
     };
     ($default:expr, $ty:ty) => {{

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -1964,7 +1964,7 @@ macro_rules! named_unit_variant {
     };
 }
 
-mod de_unit_v {
+mod unit_v {
     named_unit_variant!(all);
     named_unit_variant!(skip_trivial);
     named_unit_variant!(mutable);
@@ -2144,7 +2144,7 @@ enum CallableCompletionDef {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 enum CargoFeaturesDef {
-    #[serde(with = "de_unit_v::all")]
+    #[serde(with = "unit_v::all")]
     All,
     Selected(Vec<String>),
 }
@@ -2173,7 +2173,7 @@ enum LifetimeElisionDef {
     Always,
     #[serde(with = "false_or_never")]
     Never,
-    #[serde(with = "de_unit_v::skip_trivial")]
+    #[serde(with = "unit_v::skip_trivial")]
     SkipTrivial,
 }
 
@@ -2184,7 +2184,7 @@ enum ClosureReturnTypeHintsDef {
     Always,
     #[serde(with = "false_or_never")]
     Never,
-    #[serde(with = "de_unit_v::with_block")]
+    #[serde(with = "unit_v::with_block")]
     WithBlock,
 }
 
@@ -2204,7 +2204,7 @@ enum ReborrowHintsDef {
     Always,
     #[serde(with = "false_or_never")]
     Never,
-    #[serde(with = "de_unit_v::mutable")]
+    #[serde(with = "unit_v::mutable")]
     Mutable,
 }
 
@@ -2215,7 +2215,7 @@ enum AdjustmentHintsDef {
     Always,
     #[serde(with = "false_or_never")]
     Never,
-    #[serde(with = "de_unit_v::reborrow")]
+    #[serde(with = "unit_v::reborrow")]
     Reborrow,
 }
 
@@ -2226,7 +2226,7 @@ enum DiscriminantHintsDef {
     Always,
     #[serde(with = "false_or_never")]
     Never,
-    #[serde(with = "de_unit_v::fieldless")]
+    #[serde(with = "unit_v::fieldless")]
     Fieldless,
 }
 
@@ -2282,11 +2282,11 @@ enum WorkspaceSymbolSearchKindDef {
 #[serde(rename_all = "snake_case")]
 #[serde(untagged)]
 enum MemoryLayoutHoverRenderKindDef {
-    #[serde(with = "de_unit_v::decimal")]
+    #[serde(with = "unit_v::decimal")]
     Decimal,
-    #[serde(with = "de_unit_v::hexadecimal")]
+    #[serde(with = "unit_v::hexadecimal")]
     Hexadecimal,
-    #[serde(with = "de_unit_v::both")]
+    #[serde(with = "unit_v::both")]
     Both,
 }
 

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -22,6 +22,7 @@ use ide_db::{
     imports::insert_use::{ImportGranularity, InsertUseConfig, PrefixKind},
     SnippetCap,
 };
+use indexmap::IndexMap;
 use itertools::Itertools;
 use la_arena::Arena;
 use lsp_types::{ClientCapabilities, MarkupKind};
@@ -30,7 +31,6 @@ use project_model::{
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::collections::BTreeMap;
 use toml;
 use vfs::{AbsPath, AbsPathBuf, FileId};
 
@@ -384,8 +384,8 @@ config_data! {
         /// Enables completions of private items and fields that are defined in the current workspace even if they are not visible at the current position.
         completion_privateEditable_enable: bool = false,
         /// Custom completion snippets.
-        // NOTE: we use BTreeMap for deterministic serialization ordering
-        completion_snippets_custom: BTreeMap<String, SnippetDef> = @from_str: r#"{
+        // NOTE: we use IndexMap for deterministic serialization ordering
+        completion_snippets_custom: IndexMap<String, SnippetDef> = serde_json::from_str(r#"{
             "Arc::new": {
                 "postfix": "arc",
                 "body": "Arc::new(${receiver})",
@@ -425,7 +425,7 @@ config_data! {
                 "description": "Wrap the expression in an `Option::Some`",
                 "scope": "expr"
             }
-        }"#,
+        }"#).unwrap(),
 
         /// Enables highlighting of related references while the cursor is on `break`, `loop`, `while`, or `for` keywords.
         highlightRelated_breakPoints_enable: bool = true,
@@ -2560,7 +2560,7 @@ fn field_props(field: &str, ty: &str, doc: &[&str], default: &str) -> serde_json
         "FxHashMap<Box<str>, Box<[Box<str>]>>" => set! {
             "type": "object",
         },
-        "BTreeMap<String, SnippetDef>" => set! {
+        "IndexMap<String, SnippetDef>" => set! {
             "type": "object",
         },
         "FxHashMap<String, String>" => set! {

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -278,46 +278,46 @@ Enables completions of private items and fields that are defined in the current 
 Default:
 ----
 {
-            "Arc::new": {
-                "postfix": "arc",
-                "body": "Arc::new(${receiver})",
-                "requires": "std::sync::Arc",
-                "description": "Put the expression into an `Arc`",
-                "scope": "expr"
-            },
-            "Rc::new": {
-                "postfix": "rc",
-                "body": "Rc::new(${receiver})",
-                "requires": "std::rc::Rc",
-                "description": "Put the expression into an `Rc`",
-                "scope": "expr"
-            },
-            "Box::pin": {
-                "postfix": "pinbox",
-                "body": "Box::pin(${receiver})",
-                "requires": "std::boxed::Box",
-                "description": "Put the expression into a pinned `Box`",
-                "scope": "expr"
-            },
-            "Ok": {
-                "postfix": "ok",
-                "body": "Ok(${receiver})",
-                "description": "Wrap the expression in a `Result::Ok`",
-                "scope": "expr"
-            },
-            "Err": {
-                "postfix": "err",
-                "body": "Err(${receiver})",
-                "description": "Wrap the expression in a `Result::Err`",
-                "scope": "expr"
-            },
-            "Some": {
-                "postfix": "some",
-                "body": "Some(${receiver})",
-                "description": "Wrap the expression in an `Option::Some`",
-                "scope": "expr"
-            }
-        }
+  "Arc::new": {
+    "postfix": "arc",
+    "body": "Arc::new(${receiver})",
+    "requires": "std::sync::Arc",
+    "description": "Put the expression into an `Arc`",
+    "scope": "expr"
+  },
+  "Rc::new": {
+    "postfix": "rc",
+    "body": "Rc::new(${receiver})",
+    "requires": "std::rc::Rc",
+    "description": "Put the expression into an `Rc`",
+    "scope": "expr"
+  },
+  "Box::pin": {
+    "postfix": "pinbox",
+    "body": "Box::pin(${receiver})",
+    "requires": "std::boxed::Box",
+    "description": "Put the expression into a pinned `Box`",
+    "scope": "expr"
+  },
+  "Ok": {
+    "postfix": "ok",
+    "body": "Ok(${receiver})",
+    "description": "Wrap the expression in a `Result::Ok`",
+    "scope": "expr"
+  },
+  "Err": {
+    "postfix": "err",
+    "body": "Err(${receiver})",
+    "description": "Wrap the expression in a `Result::Err`",
+    "scope": "expr"
+  },
+  "Some": {
+    "postfix": "some",
+    "body": "Some(${receiver})",
+    "description": "Wrap the expression in an `Option::Some`",
+    "scope": "expr"
+  }
+}
 ----
 Custom completion snippets.
 


### PR DESCRIPTION
Linkage: https://github.com/rust-lang/rust-analyzer/pull/16254

Fixes:

1. Removes all of the duplication in the `config_data!` macro
2. `Option::<T>::None` everywhere by using `$ty` in the macro
3. Missing default snippet set
4. Serializing the unit values, the lack of which manifested itself as `#[serde(untagged)]` enums in an Option always rendering as `null` in the generated docs
5. Serializing `true_or_always` and `false_or_never`
6. `cargo_unsetTest` rendering differently

At this point, the generated documentation diff is down to zero, so all the tests pass.

You could probably remove the awkward `@verbatim: ` prefix from the string-valued defaults if you made everything go back to the old system of parsing a string. It's up to you, I kinda like the type-based version. Notes:

- The string-based macro was good because it at least forced you to parse one of the values, which kinda acts like a test.
   - However you could just have the macro generate a test that does a ser-de round trip for every field. As long as you made a bunch of these types PartialEq. [I did this in the branch `test-roundtrip` on my fork](https://github.com/cormacrelf/rust-analyzer/commits/test-roundtrip/), of course it fails for the two fields that use string defaults.

