### PR TITLE
Config tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,6 +793,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indextree"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c40411d0e5c63ef1323c3d09ce5ec6d84d71531e18daed0743fccea279d7deb6"
+
+[[package]]
 name = "inotify"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,6 +1592,7 @@ dependencies = [
  "ide-db",
  "ide-ssr",
  "indexmap 2.0.0",
+ "indextree",
  "itertools",
  "la-arena 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "load-cargo",
@@ -1609,6 +1616,7 @@ dependencies = [
  "scip",
  "serde",
  "serde_json",
+ "slotmap",
  "sourcegen",
  "stdx",
  "syntax",
@@ -1783,6 +1791,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "slotmap"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,12 +793,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indextree"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c40411d0e5c63ef1323c3d09ce5ec6d84d71531e18daed0743fccea279d7deb6"
-
-[[package]]
 name = "inotify"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1592,7 +1586,6 @@ dependencies = [
  "ide-db",
  "ide-ssr",
  "indexmap 2.0.0",
- "indextree",
  "itertools",
  "la-arena 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "load-cargo",
@@ -1613,10 +1606,10 @@ dependencies = [
  "rayon",
  "rustc-dependencies",
  "rustc-hash",
+ "salsa",
  "scip",
  "serde",
  "serde_json",
- "slotmap",
  "sourcegen",
  "stdx",
  "syntax",
@@ -1791,15 +1784,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "slotmap"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
-dependencies = [
- "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ nohash-hasher = "0.2.0"
 text-size = "1.1.0"
 serde = { version = "1.0.156", features = ["derive"] }
 serde_json = "1.0.96"
+salsa  = "0.17.0-pre.2"
 triomphe = { version = "0.1.8", default-features = false, features = ["std"] }
 # can't upgrade due to dashmap depending on 0.12.3 currently
 hashbrown = { version = "0.12.3", features = [

--- a/crates/base-db/Cargo.toml
+++ b/crates/base-db/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 doctest = false
 
 [dependencies]
-salsa = "0.17.0-pre.2"
+salsa.workspace = true
 rustc-hash = "1.1.0"
 
 triomphe.workspace = true

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -194,6 +194,10 @@ impl AbsPath {
         self.0.ends_with(&suffix.0)
     }
 
+    pub fn ancestors(&self) -> impl Iterator<Item = &AbsPath> {
+        self.0.ancestors().map(AbsPath::assert)
+    }
+
     pub fn name_and_extension(&self) -> Option<(&str, Option<&str>)> {
         Some((
             self.file_stem()?.to_str()?,

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -136,7 +136,8 @@ impl AbsPath {
     /// # Panics
     ///
     /// Panics if `path` is not absolute.
-    pub fn assert(path: &Path) -> &AbsPath {
+    pub fn assert<P: AsRef<Path> + ?Sized>(path: &P) -> &AbsPath {
+        let path = path.as_ref();
         assert!(path.is_absolute());
         unsafe { &*(path as *const Path as *const AbsPath) }
     }

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -75,6 +75,8 @@ toolchain.workspace = true
 vfs-notify.workspace = true
 vfs.workspace = true
 la-arena.workspace = true
+indextree = "4.6.0"
+slotmap = "1.0.7"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -75,8 +75,7 @@ toolchain.workspace = true
 vfs-notify.workspace = true
 vfs.workspace = true
 la-arena.workspace = true
-indextree = "4.6.0"
-slotmap = "1.0.7"
+salsa.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -2195,7 +2195,7 @@ enum AdjustmentHintsDef {
     Reborrow,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 enum DiscriminantHintsDef {
     #[serde(with = "true_or_always")]

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -42,6 +42,7 @@ use crate::{
 };
 
 mod patch_old_style;
+mod tree;
 
 // Conventions for configuration keys to preserve maximal extendability without breakage:
 //  - Toggles (be it binary true/false or with more options in-between) should almost always suffix as `_enable`

--- a/crates/rust-analyzer/src/config/tree.rs
+++ b/crates/rust-analyzer/src/config/tree.rs
@@ -45,13 +45,6 @@ pub struct ConfigChanges {
 }
 
 #[derive(Debug)]
-pub struct ConfigParentChange {
-    /// The config node in question
-    pub file_id: FileId,
-    pub parent: ConfigParent,
-}
-
-#[derive(Debug)]
 pub enum ConfigParent {
     /// The node is now a root in its own right, but still inherits from the config in XDG_CONFIG_HOME
     /// etc
@@ -75,11 +68,11 @@ pub enum ConfigParent {
     /// let root = vfs.set_file_contents("/project_root/rust-analyzer.toml", Some("..."));
     /// let crate_a = vfs.set_file_contents("/project_root/crate_a/rust-analyzer.toml", None);
     /// let crate_b = vfs.set_file_contents("/project_root/crate_a/crate_b/rust-analyzer.toml", Some("..."));
-    /// let config_parent_changes = [
-    ///   ConfigParentChange { node: root, parent: ConfigParent::UserDefault },
-    ///   ConfigParentChange { node: crate_a, parent: ConfigParent::Parent(root) },
-    ///   ConfigParentChange { node: crate_b, parent: ConfigParent::Parent(crate_a) }
-    /// ];
+    /// let parent_changes = FxHashMap::from_iter([
+    ///   (root, ConfigParent::UserDefault),
+    ///   (crate_a, ConfigParent::Parent(root)),
+    ///   (crate_b, ConfigParent::Parent(crate_a)),
+    /// ]);
     /// ```
     Parent(FileId),
 }

--- a/crates/rust-analyzer/src/config/tree.rs
+++ b/crates/rust-analyzer/src/config/tree.rs
@@ -1,0 +1,241 @@
+use indextree::NodeId;
+use parking_lot::{RwLock, RwLockUpgradableReadGuard};
+use rustc_hash::FxHashMap;
+use slotmap::SlotMap;
+use std::sync::Arc;
+use vfs::{FileId, Vfs};
+
+use super::{ConfigInput, LocalConfigData, RootLocalConfigData};
+
+pub struct ConcurrentConfigTree {
+    // One rwlock on the whole thing is probably fine.
+    // If you have 40,000 crates and you need to edit your config 200x/second, let us know.
+    rwlock: RwLock<ConfigTree>,
+}
+
+pub enum ConfigTreeError {
+    Removed,
+    NonExistent,
+    Utf8(vfs::VfsPath, std::str::Utf8Error),
+    TomlParse(vfs::VfsPath, toml::de::Error),
+    TomlDeserialize { path: vfs::VfsPath, field: String, error: toml::de::Error },
+}
+
+/// Some rust-analyzer.toml files have changed, and/or the LSP client sent a new configuration.
+pub struct ConfigChanges {
+    ra_toml_changes: Vec<vfs::ChangedFile>,
+    client_change: Option<Arc<ConfigInput>>,
+}
+
+impl ConcurrentConfigTree {
+    pub fn apply_changes(&self, changes: ConfigChanges, vfs: &Vfs) -> Vec<ConfigTreeError> {
+        let mut errors = Vec::new();
+        self.rwlock.write().apply_changes(changes, vfs, &mut errors);
+        errors
+    }
+    pub fn read_config(&self, file_id: FileId) -> Result<Arc<LocalConfigData>, ConfigTreeError> {
+        let reader = self.rwlock.upgradable_read();
+        if let Some(computed) = reader.read_only(file_id)? {
+            return Ok(computed);
+        } else {
+            let mut writer = RwLockUpgradableReadGuard::upgrade(reader);
+            return writer.compute(file_id);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum ConfigSource {
+    ClientConfig,
+    RaToml(FileId),
+}
+
+slotmap::new_key_type! {
+    struct ComputedIdx;
+}
+
+struct ConfigNode {
+    src: ConfigSource,
+    input: Arc<ConfigInput>,
+    computed: ComputedIdx,
+}
+
+struct ConfigTree {
+    tree: indextree::Arena<ConfigNode>,
+    client_config: NodeId,
+    ra_file_id_map: FxHashMap<FileId, NodeId>,
+    computed: SlotMap<ComputedIdx, Option<Arc<LocalConfigData>>>,
+}
+
+fn parse_toml(
+    file_id: FileId,
+    vfs: &Vfs,
+    scratch: &mut Vec<(String, toml::de::Error)>,
+    errors: &mut Vec<ConfigTreeError>,
+) -> Option<Arc<ConfigInput>> {
+    let content = vfs.file_contents(file_id);
+    let path = vfs.file_path(file_id);
+    let content_str = match std::str::from_utf8(content) {
+        Err(e) => {
+            tracing::error!("non-UTF8 TOML content for {path}: {e}");
+            errors.push(ConfigTreeError::Utf8(path, e));
+            return None;
+        }
+        Ok(str) => str,
+    };
+    let table = match toml::from_str(content_str) {
+        Ok(table) => table,
+        Err(e) => {
+            errors.push(ConfigTreeError::TomlParse(path, e));
+            return None;
+        }
+    };
+    let input = Arc::new(ConfigInput::from_toml(table, scratch));
+    scratch.drain(..).for_each(|(field, error)| {
+        errors.push(ConfigTreeError::TomlDeserialize { path: path.clone(), field, error });
+    });
+    Some(input)
+}
+
+impl ConfigTree {
+    fn new() -> Self {
+        let mut tree = indextree::Arena::new();
+        let mut computed = SlotMap::default();
+        let client_config = tree.new_node(ConfigNode {
+            src: ConfigSource::ClientConfig,
+            input: Arc::new(ConfigInput::default()),
+            computed: computed.insert(Option::<Arc<LocalConfigData>>::None),
+        });
+        Self { client_config, ra_file_id_map: FxHashMap::default(), tree, computed }
+    }
+
+    fn read_only(&self, file_id: FileId) -> Result<Option<Arc<LocalConfigData>>, ConfigTreeError> {
+        let node_id = *self.ra_file_id_map.get(&file_id).ok_or(ConfigTreeError::NonExistent)?;
+        // indextree does not check this during get(), probably for perf reasons?
+        // get() is apparently only a bounds check
+        if node_id.is_removed(&self.tree) {
+            return Err(ConfigTreeError::Removed);
+        }
+        let node = self.tree.get(node_id).ok_or(ConfigTreeError::NonExistent)?.get();
+        Ok(self.computed[node.computed].clone())
+    }
+
+    fn compute(&mut self, file_id: FileId) -> Result<Arc<LocalConfigData>, ConfigTreeError> {
+        let node_id = *self.ra_file_id_map.get(&file_id).ok_or(ConfigTreeError::NonExistent)?;
+        self.compute_inner(node_id)
+    }
+    fn compute_inner(&mut self, node_id: NodeId) -> Result<Arc<LocalConfigData>, ConfigTreeError> {
+        if node_id.is_removed(&self.tree) {
+            return Err(ConfigTreeError::Removed);
+        }
+        let node = self.tree.get(node_id).ok_or(ConfigTreeError::NonExistent)?.get();
+        let idx = node.computed;
+        let slot = &mut self.computed[idx];
+        if let Some(slot) = slot {
+            Ok(slot.clone())
+        } else {
+            let self_computed = if let Some(parent) =
+                self.tree.get(node_id).ok_or(ConfigTreeError::NonExistent)?.parent()
+            {
+                let self_input = node.input.clone();
+                let parent_computed = self.compute_inner(parent)?;
+                Arc::new(parent_computed.clone_with_overrides(self_input.local.clone()))
+            } else {
+                // We have hit a root node
+                let self_input = node.input.clone();
+                let root_local = RootLocalConfigData::from_root_input(self_input.local.clone());
+                Arc::new(root_local.0)
+            };
+            // Get a new &mut slot because self.compute(parent) also gets mut access
+            let slot = &mut self.computed[idx];
+            slot.replace(self_computed.clone());
+            Ok(self_computed)
+        }
+    }
+
+    fn insert_toml(&mut self, file_id: FileId, input: Arc<ConfigInput>) -> NodeId {
+        let computed = self.computed.insert(None);
+        let node =
+            self.tree.new_node(ConfigNode { src: ConfigSource::RaToml(file_id), input, computed });
+        self.ra_file_id_map.insert(file_id, node);
+        node
+    }
+
+    fn update_toml(
+        &mut self,
+        file_id: FileId,
+        input: Arc<ConfigInput>,
+    ) -> Result<(), ConfigTreeError> {
+        let Some(node_id) = self.ra_file_id_map.get(&file_id).cloned() else {
+            return Err(ConfigTreeError::NonExistent);
+        };
+        if node_id.is_removed(&self.tree) {
+            return Err(ConfigTreeError::Removed);
+        }
+        let node = self.tree.get_mut(node_id).ok_or(ConfigTreeError::NonExistent)?;
+        node.get_mut().input = input;
+
+        self.invalidate_subtree(node_id);
+        Ok(())
+    }
+
+    fn invalidate_subtree(&mut self, node_id: NodeId) {
+        //
+        // This is why we need the computed values outside the indextree: we iterate immutably
+        // over the tree while holding a &mut self.computed.
+        node_id.descendants(&self.tree).for_each(|x| {
+            let Some(desc) = self.tree.get(x) else {
+                return;
+            };
+            self.computed.get_mut(desc.get().computed).take();
+        });
+    }
+
+    fn remove_toml(&mut self, file_id: FileId) -> Option<()> {
+        let node_id = self.ra_file_id_map.remove(&file_id)?;
+        if node_id.is_removed(&self.tree) {
+            return None;
+        }
+        let node = self.tree.get(node_id)?;
+        let idx = node.get().computed;
+        let _ = self.computed.remove(idx);
+        self.invalidate_subtree(node_id);
+        Some(())
+    }
+
+    fn apply_changes(
+        &mut self,
+        changes: ConfigChanges,
+        vfs: &Vfs,
+        errors: &mut Vec<ConfigTreeError>,
+    ) {
+        let mut scratch_errors = Vec::new();
+        let ConfigChanges { client_change, ra_toml_changes } = changes;
+        if let Some(change) = client_change {
+            let node =
+                self.tree.get_mut(self.client_config).expect("client_config node should exist");
+            node.get_mut().input = change;
+            self.invalidate_subtree(self.client_config);
+        }
+        for change in ra_toml_changes {
+            // turn and face the strain
+            match change.change_kind {
+                vfs::ChangeKind::Create => {
+                    let input = parse_toml(change.file_id, vfs, &mut scratch_errors, errors)
+                        .unwrap_or_default();
+                    let _new_node = self.insert_toml(change.file_id, input);
+                }
+                vfs::ChangeKind::Modify => {
+                    let input = parse_toml(change.file_id, vfs, &mut scratch_errors, errors)
+                        .unwrap_or_default();
+                    if let Err(e) = self.update_toml(change.file_id, input) {
+                        errors.push(e);
+                    }
+                }
+                vfs::ChangeKind::Delete => {
+                    self.remove_toml(change.file_id);
+                }
+            }
+        }
+    }
+}

--- a/crates/rust-analyzer/src/config/tree.rs
+++ b/crates/rust-analyzer/src/config/tree.rs
@@ -647,6 +647,7 @@ mod tests {
         // from /root/rust-analyzer.toml
         assert_eq!(local.completion_autoself_enable, false);
 
+        // Send in an empty change, should have no effect
         let changes = ConfigChanges {
             client_change: None,
             set_project_root: None,
@@ -655,8 +656,6 @@ mod tests {
         };
         config_tree.apply_changes(changes, &mut vfs);
         let local = config_tree.local_config(crate_a);
-        // initially crate_a is part of the project root, so it does inherit
-        // from /root/rust-analyzer.toml
         assert_eq!(local.completion_autoself_enable, false);
     }
 }

--- a/crates/rust-analyzer/src/config/tree.rs
+++ b/crates/rust-analyzer/src/config/tree.rs
@@ -90,7 +90,7 @@ impl ConcurrentConfigTree {
         self.rwlock.write().apply_changes(changes, vfs, &mut errors);
         errors
     }
-    pub fn read_config(&self, file_id: FileId) -> Result<Arc<LocalConfigData>, ConfigTreeError> {
+    pub fn local_config(&self, file_id: FileId) -> Result<Arc<LocalConfigData>, ConfigTreeError> {
         let reader = self.rwlock.upgradable_read();
         if let Some(computed) = reader.read_only(file_id)? {
             return Ok(computed);
@@ -480,7 +480,7 @@ mod tests {
 
         dbg!(config_tree.apply_changes(changes, &vfs));
 
-        let local = config_tree.read_config(crate_a).unwrap();
+        let local = config_tree.local_config(crate_a).unwrap();
         // from root
         assert_eq!(local.completion_autoself_enable, false);
         // from crate_a
@@ -518,11 +518,11 @@ mod tests {
         dbg!(config_tree.apply_changes(changes, &vfs));
 
         let prev = local;
-        let local = config_tree.read_config(crate_a).unwrap();
+        let local = config_tree.local_config(crate_a).unwrap();
         // Should have been recomputed
         assert!(!Arc::ptr_eq(&prev, &local));
         // But without changes in between, should give the same Arc back
-        assert!(Arc::ptr_eq(&local, &config_tree.read_config(crate_a).unwrap()));
+        assert!(Arc::ptr_eq(&local, &config_tree.local_config(crate_a).unwrap()));
 
         // The newly added xdg_config_file_id should affect the output if nothing else touches
         // this key

--- a/crates/rust-analyzer/src/config/tree.rs
+++ b/crates/rust-analyzer/src/config/tree.rs
@@ -356,7 +356,6 @@ fn parse_toml(
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use itertools::Itertools;
     use vfs::{AbsPath, AbsPathBuf, VfsPath};
 
     fn alloc_file_id(vfs: &mut Vfs, s: &str) -> FileId {
@@ -496,15 +495,9 @@ mod tests {
 
         let source_roots =
             ["/root/crate_a", "/root/crate_a/crate_b"].map(Path::new).map(AbsPath::assert);
-        let source_root_tomls = source_roots
-            .iter()
+        let [crate_a, crate_b] = source_roots
             .map(|dir| dir.join("rust-analyzer.toml"))
-            .map(|path| AbsPathBuf::try_from(path).unwrap())
-            .map(|path| vfs.alloc_file_id(path.into()))
-            .collect_vec();
-        let &[crate_a, crate_b] = &source_root_tomls[..] else {
-            panic!();
-        };
+            .map(|path| vfs.alloc_file_id(path.into()));
 
         vfs.set_file_id_contents(
             xdg,

--- a/crates/vfs/src/lib.rs
+++ b/crates/vfs/src/lib.rs
@@ -133,11 +133,6 @@ impl Vfs {
         self.get(file_id).as_deref().unwrap()
     }
 
-    /// File content, but returns None if the file was deleted.
-    pub fn file_contents_opt(&self, file_id: FileId) -> Option<&[u8]> {
-        self.get(file_id).as_deref()
-    }
-
     /// Returns the overall memory usage for the stored files.
     pub fn memory_usage(&self) -> usize {
         self.data.iter().flatten().map(|d| d.capacity()).sum()
@@ -167,6 +162,12 @@ impl Vfs {
         self.set_file_id_contents(file_id, contents)
     }
 
+    /// Update the given `file_id` with the given `contents`. `None` means the file was deleted.
+    ///
+    /// Returns `true` if the file was modified, and saves the [change](ChangedFile).
+    ///
+    /// If the path does not currently exists in the `Vfs`, allocates a new
+    /// [`FileId`] for it.
     pub fn set_file_id_contents(&mut self, file_id: FileId, mut contents: Option<Vec<u8>>) -> bool {
         let change_kind = match (self.get(file_id), &contents) {
             (None, None) => return false,


### PR DESCRIPTION
Linkage: https://github.com/rust-lang/rust-analyzer/pull/16254

Ok, another PR. This is what I made, and it was fun, but I think you should probably throw most of it out and use some salsa queries, because I ended up doing quite a lot of manual invalidation.

Basically, the tree is represented by a bunch of parent relationships in `ConfigChanges.parent_changes`. When you load your workspace, you `std::path::Path::ancestors` + `.join("rust-analyzer.toml")` your way to a hash map of FileId -> parent rust-analyzer.toml FileId. This implementation doesn't assume the FileIds will exist, so the `Vfs::alloc_file_id` method is made public.

This PR does not handle constructing the parent hashmap, but it does implement the tree itself and actually overriding the configs on demand.

The good bits possibly to keep:

- `struct ConfigChanges` + `enum ConfigParent`  + `ConcurrentConfigTree::apply_changes` to set the salsa inputs if they've changed
- The parent data is stored via `#[salsa::input] fn parent_ra_toml(FileId) -> FileId`
- The client config is stored via another salsa::input
- `ConcurrentConfigTree::local_config(FileId) -> Arc<LocalConfigData>` becomes a salsa query. Ignore the RwLock stuff, salsa does that.
   - The top level query overrides with the client config. The thing it overrides is the output of compute_recursive.
   - `compute_recursive` also becomes a query. It should return some default value if you accidentally make it cyclic (i.e. `parent_ra_toml(x) == x`) lest we crash salsa
- You can probably keep the test at the bottom, only changing the constructor.